### PR TITLE
revising inter_ver to intel_ver in ecf scripts

### DIFF
--- a/ecf/jnwps_forecast_cg1.ecf
+++ b/ecf/jnwps_forecast_cg1.ecf
@@ -15,7 +15,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load wgrib2/${wgrib2_ver}

--- a/ecf/jnwps_forecast_cgn.ecf
+++ b/ecf/jnwps_forecast_cgn.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load python/${python_ver}

--- a/ecf/jnwps_ofs_prep.ecf
+++ b/ecf/jnwps_ofs_prep.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/jnwps_post_cg1.ecf
+++ b/ecf/jnwps_post_cg1.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load cfp/${cfp_ver}

--- a/ecf/jnwps_post_cgn.ecf
+++ b/ecf/jnwps_post_cgn.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load cfp/${cfp_ver}

--- a/ecf/jnwps_prdgen_cg0.ecf
+++ b/ecf/jnwps_prdgen_cg0.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load libjpeg/${libjpeg_ver}

--- a/ecf/jnwps_prdgen_cg1.ecf
+++ b/ecf/jnwps_prdgen_cg1.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load libjpeg/${libjpeg_ver}

--- a/ecf/jnwps_prdgen_cgn.ecf
+++ b/ecf/jnwps_prdgen_cgn.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load libjpeg/${libjpeg_ver}

--- a/ecf/jnwps_prep.ecf
+++ b/ecf/jnwps_prep.ecf
@@ -15,7 +15,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load perl/${perl_ver}

--- a/ecf/jnwps_psurge_prep.ecf
+++ b/ecf/jnwps_psurge_prep.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/jnwps_rtofs_prep.ecf
+++ b/ecf/jnwps_rtofs_prep.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/jnwps_stofs_prep.ecf
+++ b/ecf/jnwps_stofs_prep.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/jnwps_wavetrack_cg1.ecf
+++ b/ecf/jnwps_wavetrack_cg1.ecf
@@ -14,7 +14,7 @@ export model=nwps
 %include <envir-p1.h>
 
 module load craype/${craype_ver}
-module load intel/${inter_ver}
+module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load wgrib2/${wgrib2_ver}
 module load cfp/${cfp_ver}


### PR DESCRIPTION
NCO requested to fix the inter_ver typo to intel_ver in the ecf/jnwps*.ecf files.