### PR TITLE
using emapf-c from module instead of installing it

### DIFF
--- a/modulefiles/build_nwps.modules
+++ b/modulefiles/build_nwps.modules
@@ -35,5 +35,6 @@ module load g2c/${g2c_ver}
 # used for multiwavegrib1 and grib2
 module load w3nco/${w3nco_ver}
 module load bacio/${bacio_ver}
+module load emapf-c/${emapfc_ver}
 # used for io buffering
 #module load iobuf/${iobuf_ver}

--- a/modulefiles/build_nwps.modules.lua
+++ b/modulefiles/build_nwps.modules.lua
@@ -35,3 +35,4 @@ load("g2c/"..os.getenv("g2c_ver"))
 -- used for multiwavegrib1 and grib2
 load("w3nco/"..os.getenv("w3nco_ver"))
 load("bacio/"..os.getenv("bacio_ver"))
+load("emapf-c/"..os.getenv("emapfc_ver"))

--- a/sorc/degrib-2.15.cd/Makefile
+++ b/sorc/degrib-2.15.cd/Makefile
@@ -13,7 +13,8 @@ CC      = $(C_COMP)
 # Various directories
 BINDIR = ../../exec
 LIBDIR = ../../lib
-EMAPF_SRC = $(LIBDIR)/sorc/emapf-c
+#EMAPF_SRC = $(LIBDIR)/sorc/emapf-c
+EMAPF_SRC = $(EMAPF_INC)/sorc/emapf-c
 GD_SRC = /usr/include
 
 # Compiler flags
@@ -33,7 +34,8 @@ INC    += -I$(GD_SRC)
 CFLAGS += -I. $(INC)
 
 # Libraries and linker flags
-EMAPF_LIB = $(LIBDIR)/libemapf.a
+#EMAPF_LIB = $(LIBDIR)/libemapf.a
+EMAPF_LIB = $(EMAPF_INC)/libemapf.a
 GD_LIB = -L /usr/lib64/ -lgd
 LIBS    = $(G2C_LIB) $(GD_LIB) $(PNG_LIB) $(Z_LIB) $(JASPER_LIB) $(EMAPF_LIB)
 LDFLAGS =

--- a/sorc/degrib-2.15.cd/build.sh
+++ b/sorc/degrib-2.15.cd/build.sh
@@ -29,7 +29,8 @@ function build_dir {
    echo "=============================="
    echo "Check library depends..."
    echo "------------------------------"
-   LIBDIR=$srcDir/../lib
+   #LIBDIR=$srcDir/../lib
+   LIBDIR=$EMAPF_INC
    if [[ $1 == "psurge_envmerge.cd" || $1 == "drawshp.cd" || \
          $1 == "degrib-2.15.cd" ]] ; then
       LIB=$LIBDIR/libemapf.a

--- a/sorc/make_degrib-2.15.sh
+++ b/sorc/make_degrib-2.15.sh
@@ -28,9 +28,9 @@ cd ${NWPSdir}/sorc/degrib-2.15.cd/
 ./build.sh degrib-2.15 clean | tee -a ${srcDir}/degrib-2.15.cd/degrib_build.log
 
 # Build libemapf.a
-echo "Building libemapf.a..." | tee -a ${srcDir}/degrib-2.15.cd/degrib_build.log
-cd ${NWPSdir}/lib/sorc/emapf-c
-make clean install | tee -a ${srcDir}/degrib-2.15.cd/degrib_build.log
+#echo "Building libemapf.a..." | tee -a ${srcDir}/degrib-2.15.cd/degrib_build.log
+#cd ${NWPSdir}/lib/sorc/emapf-c
+#make clean install | tee -a ${srcDir}/degrib-2.15.cd/degrib_build.log
 
 # Build libgd.a
 #echo "Building libgd.a..." | tee -a ${srcDir}/degrib-2.15.cd/degrib_build.log

--- a/sorc/make_psurge2nwps.sh
+++ b/sorc/make_psurge2nwps.sh
@@ -13,10 +13,10 @@ fi
 #module list
 
 echo "Building psoutTOnwps"  | tee ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
-cd ${NWPSdir}/sorc/emapf-c
-./configure --prefix=${NWPSdir}/sorc/emapf-c CC=cc | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
-make clean | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
-make | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
+#cd ${NWPSdir}/sorc/emapf-c
+#./configure --prefix=${NWPSdir}/sorc/emapf-c CC=cc | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
+#make clean | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
+#make | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log
 
 cd ${NWPSdir}/sorc/libaat
 ./configure --prefix=${NWPSdir}/sorc/libaat CC=cc | tee -a ${NWPSdir}/sorc/psurge2nwps.cd/psoutTOnwps_build.log

--- a/sorc/psurge2nwps.cd/makefile
+++ b/sorc/psurge2nwps.cd/makefile
@@ -102,9 +102,10 @@ STD_LIB += -L../libaat -laat
 # Add emapf-c to Build path
 #STD_INC += -I../emapf-c
 #STD_LIB += -L../emapf-c -lemapf
-STD_INC += -I../../lib/sorc/emapf-c
-STD_LIB += -L../../lib -lemapf
-
+#STD_INC += -I../../lib/sorc/emapf-c
+#STD_LIB += -L../../lib -lemapf
+STD_INC += -I$(EMAPF_INC)/sorc/emapf-c
+STD_LIB += -L$(EMAPF_INC) -lemapf
 ifeq ($(BIT),32)
   STD_LIB += -L/usr/lib -lm
 else

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -13,3 +13,5 @@ export w3nco_ver=2.4.1
 export bacio_ver=2.4.1
 export hdf5_ver=1.8.9
 export netcdf_ver=4.2
+export emapfc_ver=1.0.0
+


### PR DESCRIPTION
This PR will load the emapf-c from wcoss2 modules and using it instead of installing the emapf-c.