### PR TITLE
handling the 0 byte upstream file forcing (stofs, rtofs, psurge) and

### DIFF
--- a/ush/get_ncep_initfiles.sh
+++ b/ush/get_ncep_initfiles.sh
@@ -91,6 +91,46 @@ echo "Downloading NCEP init files for NWPS"
 
 /bin/mkdir -p ${LDMdir}/rtofs ${LDMdir}/estofs ${LDMdir}/psurge
 
+
+list_zerobyte_files_in_dir () {
+  # $1 = directory
+  # $2 = filename glob (e.g. "wave_rtofs_uv_*.dat")
+  local d="$1"
+  local g="$2"
+  [ -d "$d" ] || return 0
+  find "$d" -maxdepth 1 -type f -name "$g" -size 0 -print | sort
+}
+
+warn_and_disable_forcing () {
+  # $1 = tag (RTOFS/ESTOFS/PSURGE)
+  # $2 = full warning message
+  # $3 = flag file to touch (e.g. ${RUNdir}/nortofs)
+  # $4 = optional list of 0-byte files (full paths), may be empty
+  local tag="$1"
+  local msg="$2"
+  local flag="$3"
+  local files="$4"
+  local warnfile="${RUNdir}/Warn_Forecaster_${SITEID}.${PDY}.txt"
+
+  mkdir -p "$COMOUTCYC" "$GESOUT/warnings"
+
+  echo "WARNING: ${msg}" | tee -a "${LOGfile}" "${warnfile}"
+  cp -fv "${warnfile}" "${COMOUTCYC}/Warn_Forecaster_${SITEID}.${PDY}.txt" >/dev/null 2>&1 || true
+  cp -fv "${warnfile}" "${GESOUT}/warnings/Warn_Forecaster_${SITEID}.${PDY}.txt" >/dev/null 2>&1 || true
+  postmsg "$jlogfile" "WARNING: ${msg}"
+
+  # put file list detail in LOG only
+  if [ -n "$files" ]; then
+    {
+      echo "WARNING: ${tag}: 0-byte forcing files detected:"
+      echo "$files"
+    } >> "${LOGfile}"
+  fi
+
+  touch "$flag"
+}
+
+
 if [ $1 == "RTOFS" ]
 then
    cd ${LDMdir}/rtofs
@@ -98,12 +138,20 @@ then
    if [ $# -eq 1 ]
    then
       echo "Downloading RTOFS Data. Checking Yesterday First."
-      #${WGET} ${WGETargs} http://${SITE}/${RTOFSPATHY}
-      if [ -e ${COMINrtofsm1}/LOCKFILE ]; then sleep 600; fi 
+      if [ -e ${COMINrtofsm1}/LOCKFILE ]; then sleep 600; fi
       if [ -e ${COMINrtofsm1}/rtofs_current_start_time.txt ]
       then
-         cp -pfv ${COMINrtofsm1}/* .
-         rm -fr index.* robots.*
+         zfiles=$(list_zerobyte_files_in_dir "${COMINrtofsm1}" "wave_rtofs_uv_*.dat")
+         if [ -n "$zfiles" ]; then
+            warn_and_disable_forcing \
+              "RTOFS" \
+              "There are invalid RTOFS data in ${COMINrtofsm1} (0-byte *.dat files). Run will continue without surface current fields." \
+              "${RUNdir}/nortofs" \
+              "$zfiles"
+         else
+            cp -pfv ${COMINrtofsm1}/* .
+            rm -fr index.* robots.*
+         fi
       else
          echo "WARNING: Optional RTOFS data not available for Yesterday."
       fi
@@ -141,8 +189,17 @@ then
       if [ -e ${COMINrtofs}/LOCKFILE ]; then sleep 600; fi
       if [ -e ${COMINrtofs}/rtofs_current_start_time.txt ]
       then
-         cp -pfv ${COMINrtofs}/* .
-         rm -fr index.* robots.*
+         zfiles=$(list_zerobyte_files_in_dir "${COMINrtofs}" "wave_rtofs_uv_*.dat")
+	 if [ -n "$zfiles" ]; then
+            warn_and_disable_forcing \
+              "RTOFS" \
+              "There are invalid RTOFS data in ${COMINrtofs} (0-byte *.dat files). Run will continue without surface current fields." \
+              "${RUNdir}/nortofs" \
+              "$zfiles"
+         else
+            cp -pfv ${COMINrtofs}/* .
+	    rm -fr index.* robots.*
+	 fi
       else
          echo "WARNING: Optional RTOFS data not available for Today."
       fi
@@ -188,10 +245,19 @@ then
       if [ -e ${COMINestofsm1}/LOCKFILE ]; then sleep 600; fi 
       if [ -e ${COMINestofsm1}/estofs_current_start_time.txt ]
       then
-         cp -pfv ${COMINestofsm1}/wave_estofs_uv* .
-         cp -pfv ${COMINestofsm1}/estofs_current_domain.txt .
-         cp -pfv ${COMINestofsm1}/estofs_current_start_time.txt .
-         rm -fr index.* robots.*
+         zfiles=$(list_zerobyte_files_in_dir "${COMINestofsm1}" "wave_estofs_uv*.dat")
+	 if [ -n "$zfiles" ]; then
+	    warn_and_disable_forcing \
+              "ESTOFS" \
+              "There are invalid ESTOFS current data in ${COMINestofsm1} (0-byte *.dat files). Run will continue without current." \
+              "${RUNdir}/noestofs_cur" \
+              "$zfiles"
+         else   	      
+	    cp -pfv ${COMINestofsm1}/wave_estofs_uv* .
+            cp -pfv ${COMINestofsm1}/estofs_current_domain.txt .
+            cp -pfv ${COMINestofsm1}/estofs_current_start_time.txt .
+            rm -fr index.* robots.*
+	 fi
       else
          echo "WARNING: Optional ESTOFS current data not available for Yesterday."
       fi
@@ -201,10 +267,19 @@ then
    if [ -e ${COMINestofs}/LOCKFILE ]; then sleep 600; fi
    if [ -e ${COMINestofs}/estofs_current_start_time.txt ]
    then
-      cp -pfv ${COMINestofs}/wave_estofs_uv* .
-      cp -pfv ${COMINestofs}/estofs_current_domain.txt .
-      cp -pfv ${COMINestofs}/estofs_current_start_time.txt .
-      rm -fr index.* robots.*
+      zfiles=$(list_zerobyte_files_in_dir "${COMINestofs}" "wave_estofs_uv*.dat")
+      if [ -n "$zfiles" ]; then
+	 warn_and_disable_forcing \
+           "ESTOFS" \
+           "There are invalid ESTOFS current data in ${COMINestofs} (0-byte *.dat files). Run will continue without current." \
+           "${RUNdir}/noestofs_cur" \
+	   "$zfiles"
+      else
+         cp -pfv ${COMINestofs}/wave_estofs_uv* .
+         cp -pfv ${COMINestofs}/estofs_current_domain.txt .
+         cp -pfv ${COMINestofs}/estofs_current_start_time.txt .
+         rm -fr index.* robots.*
+      fi
    else
       echo "WARNING: Optional ESTOFS current data not available for Today."
    fi
@@ -247,10 +322,19 @@ then
       if [ -e ${COMINestofsm1}/LOCKFILE ]; then sleep 600; fi 
       if [ -e ${COMINestofsm1}/estofs_waterlevel_start_time.txt ]
       then
-         cp -pfv ${COMINestofsm1}/wave_estofs_waterlevel* .
-         cp -pfv ${COMINestofsm1}/estofs_waterlevel_domain.txt .
-         cp -pfv ${COMINestofsm1}/estofs_waterlevel_start_time.txt .
-         rm -fr index.* robots.*
+         zfiles=$(list_zerobyte_files_in_dir "${COMINestofsm1}" "wave_estofs_waterlevel*.dat")
+	 if [ -n "$zfiles" ]; then
+            warn_and_disable_forcing \
+              "ESTOFS" \
+              "There are invalid ESTOFS/Sea Ice data in ${COMINestofsm1} (0-byte *.dat files). Run will continue without water level variation and ice blocking." \
+              "${RUNdir}/noestofs" \
+              "$zfiles"
+         else
+            cp -pfv ${COMINestofsm1}/wave_estofs_waterlevel* .
+            cp -pfv ${COMINestofsm1}/estofs_waterlevel_domain.txt .
+            cp -pfv ${COMINestofsm1}/estofs_waterlevel_start_time.txt .
+            rm -fr index.* robots.*
+	 fi
       else
          echo "WARNING: Optional ESTOFS data not available for Yesterday."
       fi
@@ -260,10 +344,19 @@ then
    if [ -e ${COMINestofs}/LOCKFILE ]; then sleep 600; fi
    if [ -e ${COMINestofs}/estofs_waterlevel_start_time.txt ]
    then
-      cp -pfv ${COMINestofs}/wave_estofs_waterlevel* .
-      cp -pfv ${COMINestofs}/estofs_waterlevel_domain.txt .
-      cp -pfv ${COMINestofs}/estofs_waterlevel_start_time.txt .
-      rm -fr index.* robots.*
+      zfiles=$(list_zerobyte_files_in_dir "${COMINestofs}" "wave_estofs_waterlevel*.dat")
+      if [ -n "$zfiles" ]; then
+         warn_and_disable_forcing \
+           "ESTOFS" \
+           "There are invalid ESTOFS/Sea Ice data in ${COMINestofs} (0-byte *.dat files). Run will continue without water level variation and ice blocking." \
+           "${RUNdir}/noestofs" \
+           "$zfiles"
+      else
+         cp -pfv ${COMINestofs}/wave_estofs_waterlevel* .
+         cp -pfv ${COMINestofs}/estofs_waterlevel_domain.txt .
+         cp -pfv ${COMINestofs}/estofs_waterlevel_start_time.txt .
+         rm -fr index.* robots.*
+      fi
    else
       echo "WARNING: Optional ESTOFS data not available for Today."
    fi
@@ -307,13 +400,22 @@ then
       #cp -pfv ${ES_RTOFS_PSurgedir}/${PSURGEPATHY}/wave_psurge_*_${siteid}_e${EXCD}.dat.tar.gz .
       if [ -e ${COMINpsurgem1}/psurge_waterlevel_start_time.txt ]
       then
-         #cp -pfv ${COMINpsurgem1}/wave_psurge_*_${siteid}_e${EXCD}_f*.dat .
-         cp -pfv ${COMINpsurgem1}/wave_combnd_*_${siteid}_e${EXCD}_f*.dat .
-         cp -pfv ${COMINpsurgem1}/psurge_waterlevel_domain_${siteid}.txt .
-         cp -pfv ${COMINpsurgem1}/psurge_waterlevel_start_time.txt .
-         rm -fr index.* robots.*
-         PSfiles_exist="TRUE"
-         chmod 664 *.dat
+         zfiles=$(list_zerobyte_files_in_dir "${COMINpsurgem1}" "wave_combnd_*_${siteid}_e${EXCD}_f*.dat")
+	 if [ -n "$zfiles" ]; then
+            warn_and_disable_forcing \
+              "PSURGE" \
+              "There are invalid PSURGE fields in ${COMINpsurgem1} (0-byte *.dat files). PSURGE will not be used; fallback will follow original logic." \
+              "${RUNdir}/nopsurge" \
+              "$zfiles"
+         else
+            #cp -pfv ${COMINpsurgem1}/wave_psurge_*_${siteid}_e${EXCD}_f*.dat .
+            cp -pfv ${COMINpsurgem1}/wave_combnd_*_${siteid}_e${EXCD}_f*.dat .
+            cp -pfv ${COMINpsurgem1}/psurge_waterlevel_domain_${siteid}.txt .
+            cp -pfv ${COMINpsurgem1}/psurge_waterlevel_start_time.txt .
+            rm -fr index.* robots.*
+            PSfiles_exist="TRUE"
+            chmod 664 *.dat
+	 fi
       else
          echo "WARNING: Optional PSURGE data not available for Yesterday."
       fi
@@ -326,13 +428,22 @@ then
    #cp -pfv ${ES_RTOFS_PSurgedir}/${PSURGEPATH}/wave_psurge_*_${siteid}_e${EXCD}.dat.tar.gz .
    if [ -e ${COMINpsurge}/psurge_waterlevel_start_time.txt ]
    then
-      #cp -pfv ${COMINpsurge}/wave_psurge_*_${siteid}_e${EXCD}_f*.dat .
-      cp -pfv ${COMINpsurge}/wave_combnd_*_${siteid}_e${EXCD}_f*.dat .
-      cp -pfv ${COMINpsurge}/psurge_waterlevel_domain_${siteid}.txt .
-      cp -pfv ${COMINpsurge}/psurge_waterlevel_start_time.txt .
-      rm -fr index.* robots.*
-      #PSfiles_exist="TRUE"
-      chmod 664 *.dat
+      zfiles=$(list_zerobyte_files_in_dir "${COMINpsurge}" "wave_combnd_*_${siteid}_e${EXCD}_f*.dat")
+      if [ -n "$zfiles" ]; then
+         warn_and_disable_forcing \
+           "PSURGE" \
+           "There are invalid PSURGE fields in ${COMINpsurge} (0-byte *.dat files). PSURGE will not be used; fallback will follow original logic." \
+           "${RUNdir}/nopsurge" \
+           "$zfiles"
+      else
+         #cp -pfv ${COMINpsurge}/wave_psurge_*_${siteid}_e${EXCD}_f*.dat .
+         cp -pfv ${COMINpsurge}/wave_combnd_*_${siteid}_e${EXCD}_f*.dat .
+         cp -pfv ${COMINpsurge}/psurge_waterlevel_domain_${siteid}.txt .
+         cp -pfv ${COMINpsurge}/psurge_waterlevel_start_time.txt .
+         rm -fr index.* robots.*
+         #PSfiles_exist="TRUE"
+         chmod 664 *.dat
+      fi
    else
       echo "WARNING: Optional PSURGE data not available for Today."
    fi

--- a/ush/get_ncep_initfiles.sh
+++ b/ush/get_ncep_initfiles.sh
@@ -145,7 +145,7 @@ then
          if [ -n "$zfiles" ]; then
             warn_and_disable_forcing \
               "RTOFS" \
-              "There are invalid RTOFS data in ${COMINrtofsm1} (0-byte *.dat files). Run will continue without surface current fields." \
+              "There are invalid RTOFS data in ${COMINrtofsm1} (0-byte *.dat files). Run will try Today's data." \
               "${RUNdir}/nortofs" \
               "$zfiles"
          else

--- a/ush/make_estofs.sh
+++ b/ush/make_estofs.sh
@@ -45,6 +45,26 @@ TIMESTEP="${ESTOFSTIMESTEP}"
 
 if [ "${ESTOFS_REGION}" == "" ]; then ESTOFS_REGION="conus.east"; fi
 
+check_bad_grib2_file() {
+    f="${1}"
+
+    if [ ! -e "${f}" ]; then
+        return 1
+    fi
+
+    if [ ! -s "${f}" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+warn_and_disable_estofs_grib2() {
+    msg="${1}"
+    echo "WARNING: ${msg}" | tee -a ${LOGfile}
+    touch ${RUNdir}/noestofs
+}
+
 function MakeClip() {
     DIR=${1}
     FILE=${2}
@@ -175,6 +195,12 @@ function process_wfolist() {
         fi
 
         echo "Downloading ${SPOOLdir}/$file to $outfile" 
+        echo "Checking source GRIB2 file ${COMINestofs}/${file}"
+        if ! check_bad_grib2_file "${COMINestofs}/${file}"; then
+           warn_and_disable_estofs_grib2 "ESTOFS GRIB2 file ${COMINestofs}/${file} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
+           rm -f ${OUTPUTdir}/LOCKFILE
+           return
+        fi
         echo "cp -rp ${COMINestofs}/${file} ."
         cp -rp ${COMINestofs}/${file} .
         if [ "$?" != "0" ] && [ ! -e ${file} ];then
@@ -193,6 +219,11 @@ function process_wfolist() {
 
             echo "Downloading ${SPOOLdir}/$icefile"
             if [ -e ${COMINsice}/${icefile} ];then
+               if ! check_bad_grib2_file "${COMINsice}/${icefile}"; then
+                   warn_and_disable_estofs_grib2 "Sea ice GRIB2 file ${COMINsice}/${icefile} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
+                   rm -f ${OUTPUTdir}/LOCKFILE
+                   return
+               fi
                echo "cp -rp ${COMINsice}/${icefile} ."
                cp -rp ${COMINsice}/${icefile} .
 
@@ -208,6 +239,11 @@ function process_wfolist() {
 
             elif [ -e ${COMINsicem1}/${icefile} ];then
                echo "Today's ice concentration file not yet available. Downloading yesterday's file."
+               if ! check_bad_grib2_file "${COMINsicem1}/${icefile}"; then
+                   warn_and_disable_estofs_grib2 "Sea ice GRIB2 file ${COMINsicem1}/${icefile} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
+                   rm -f ${OUTPUTdir}/LOCKFILE
+                   return
+               fi
                echo "cp -rp ${COMINsicem1}/${icefile} ."
                cp -rp ${COMINsicem1}/${icefile} .
 
@@ -330,6 +366,12 @@ function process_wfolist() {
     	outfile="${file}"
     	cd ${PRODUCTdir}
     	if [ ! -e ${VARdir}/hasestofsdownload_${CYCLE}z.${ESTOFS_BASIN}.${ESTOFS_REGION}.f${FF} ];then
+            echo "Checking source GRIB2 file ${COMINestofs}/${file}"
+            if ! check_bad_grib2_file "${COMINestofs}/${file}"; then
+                warn_and_disable_estofs_grib2 "ESTOFS GRIB2 file ${COMINestofs}/${file} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
+                rm -f ${OUTPUTdir}/LOCKFILE
+                return
+            fi
 	        echo "Copying ${COMINestofs}/${file} ${PRODUCTdir}/${file}"
 	        echo "cp -rp ${COMINestofs}/${file} ."
 	        cp -rp ${COMINestofs}/${file} .

--- a/ush/make_estofs_cur.sh
+++ b/ush/make_estofs_cur.sh
@@ -54,6 +54,25 @@ TIMESTEP="${ESTOFSTIMESTEP}"
 
 if [ "${ESTOFSCUR_REGION}" == "" ]; then ESTOFSCUR_REGION="conus.east"; fi
 
+check_bad_nc_file() {
+    f="${1}"
+
+    if [ ! -e "${f}" ]; then
+        return 1
+    fi
+
+    if [ ! -s "${f}" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+warn_and_disable_estofscur_nc() {
+    msg="${1}"
+    echo "WARNING: ${msg}" | tee -a ${LOGfile}
+}
+
 function process_wfolist() {
     WFO=$(echo ${site} | tr [:lower:] [:upper:])
     wfo=$(echo ${site} | tr [:upper:] [:lower:])
@@ -140,6 +159,11 @@ function process_wfolist() {
         # Copy ESTOFS nowcast output
         echo "Downloading ${SPOOLdir}/$file1 to $outfile1" 
         echo "cp -p ${COMINestofscur}/${file1} ."
+        if ! check_bad_nc_file "${COMINestofscur}/${file1}"; then
+           warn_and_disable_estofscur_nc "ESTOFS current file ${COMINestofscur}/${file1} is missing or 0-byte. Run will continue without ESTOFS current fields for ${WFO}."
+           rm -f ${OUTPUTdir}/LOCKFILE
+           return
+        fi
         cp -rp ${COMINestofscur}/${file1} .
         sleep 10
         if [ "$?" != "0" ] && [ ! -e ${file1} ];then
@@ -156,6 +180,11 @@ function process_wfolist() {
         # Copy ESTOFS forecast output
         echo "Downloading ${SPOOLdir}/$file2 to $outfile2" 
         echo "cp -p ${COMINestofscur}/${file2} ."
+        if ! check_bad_nc_file "${COMINestofscur}/${file2}"; then
+           warn_and_disable_estofscur_nc "ESTOFS current file ${COMINestofscur}/${file2} is missing or 0-byte. Run will continue without ESTOFS current fields for ${WFO}."
+           rm -f ${OUTPUTdir}/LOCKFILE
+           return
+        fi
         cp -rp ${COMINestofscur}/${file2} .
         sleep 10
         if [ "$?" != "0" ] && [ ! -e ${file2} ];then

--- a/ush/make_psurge_init.sh
+++ b/ush/make_psurge_init.sh
@@ -58,6 +58,26 @@ if [ "$6" != "" ]; then DOWNLOADRETRIES="$6"; fi
 WGETargs="-N -nv --tries=${DOWNLOADRETRIES} --no-remove-listing --append-output=${LOGfile}"
 WGET="/usr/bin/wget"
 
+check_bad_grib2_file() {
+    f="${1}"
+
+    if [ ! -e "${f}" ]; then
+        return 1
+    fi
+
+    if [ ! -s "${f}" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+warn_and_disable_psurge_grib2() {
+    msg="${1}"
+    echo "WARNING - ${msg}" | tee -a ${LOGfile}
+    touch ${RUNdir}/nopsurge
+}
+
 # The forecast cycle, default to 00
 CYCLE="00"	
 # Check for command line CYCLE
@@ -140,6 +160,19 @@ for part in ${split[@]} ; do echo $part; done
 #cp ${PSurge_latest}/${split[0]}_e??_inc_dat.h102.conus_625m.grib2 ${RUNdir} 
 #cp ${PSurge_latest}/${split[0]}_e[1-5]?_inc_dat.h102.conus_625m.grib2 ${RUNdir} 
 # psurge update v3.0 
+for srcfile in ${PSurge_latest}/psurge.${YYYYMMDD}/*.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2
+do
+   if [ -f "${srcfile}" ]; then
+      if ! check_bad_grib2_file "${srcfile}"; then
+         warn_and_disable_psurge_grib2 "PSURGE GRIB2 file ${srcfile} is missing or 0-byte. Run will continue without PSURGE water level variation."
+         cd ${workdir}
+         echo "Exiting make_psurge_init.sh" | tee -a ${LOGfile}
+         date
+         echo ""
+         exit 0
+      fi
+   fi
+done
 cp ${PSurge_latest}/psurge.${YYYYMMDD}/*.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2 ${RUNdir}
 cd $workdir
 #--------------------------------------------------------------
@@ -162,6 +195,14 @@ echo "Find GRIB2 files for data extraction, starting with 10% exceedance..."
 for file in *.grib2
 do
    if [ -f "$file" ];then
+      if ! check_bad_grib2_file "${RUNdir}/${file}"; then
+         warn_and_disable_psurge_grib2 "PSURGE GRIB2 file ${RUNdir}/${file} is missing or 0-byte. Run will continue without PSURGE water level variation."
+         cd ${myPWD}
+         echo "Exiting make_psurge_init.sh" | tee -a ${LOGfile}
+         date
+         echo ""
+         exit 0
+      fi
       echo "FILE FOUND: $file"
       pwd
       #ls -lt 

--- a/ush/rtofs/bin/make_rtofs_sector.sh
+++ b/ush/rtofs/bin/make_rtofs_sector.sh
@@ -68,6 +68,25 @@ if [ "$5" != "" ]; then DOWNLOADRETRIES="$5"; fi
 WGETargs="-N -nv --tries=${DOWNLOADRETRIES} --no-remove-listing --append-output=${LOGfile}"
 WGET="/usr/bin/wget"
 
+check_bad_grib2_file() {
+    f="${1}"
+
+    if [ ! -e "${f}" ]; then
+        return 1
+    fi
+
+    if [ ! -s "${f}" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+warn_and_disable_rtofs_grib2() {
+    msg="${1}"
+    echo "WARNING - ${msg}" | tee -a ${LOGfile}
+}
+
 # The forecast cycle, default to 00
 CYCLE="00"	
 # Check for command line CYCLE
@@ -234,6 +253,12 @@ do
     outfile="${file}"
     cd ${SPOOLdir}
     echo "Downloading ${COMINrtofs}/$file to $outfile" | tee -a ${LOGfile}
+    if ! check_bad_grib2_file "${COMINrtofs}/${file}"; then
+        warn_and_disable_rtofs_grib2 "RTOFS GRIB2 file ${COMINrtofs}/${file} is missing or 0-byte. Run will continue without surface current fields."
+        cd ${myPWD}
+        echo "Exiting..." | tee -a ${LOGfile}
+        exit 0
+    fi
     #echo "$WGET ${WGETargs} ${url}/${file}" | tee -a ${LOGfile} 2>&1
     #$WGET ${WGETargs} ${url}/${file} | tee -a ${LOGfile} 2>&1
     cp -rp ${COMINrtofs}/${file} .
@@ -367,6 +392,12 @@ do
 	outfile="${file}"
 	cd ${SPOOLdir}
 	echo "Downloading $url/$file to $outfile" | tee -a ${LOGfile}
+        if ! check_bad_grib2_file "${COMINrtofs}/${file}"; then
+            warn_and_disable_rtofs_grib2 "RTOFS GRIB2 file ${COMINrtofs}/${file} is missing or 0-byte. Run will continue without surface current fields."
+            cd ${myPWD}
+            echo "Exiting..." | tee -a ${LOGfile}
+            exit 0
+        fi
 	#echo "$WGET ${WGETargs} ${url}/${file}" | tee -a ${LOGfile} 2>&1
 	#$WGET ${WGETargs} ${url}/${file} | tee -a ${LOGfile} 2>&1
 	cp -rp ${COMINrtofs}/${file} .


### PR DESCRIPTION
The ush/get_ncep_initials.sh is revised to check the COMINs for 0 byte .dat file coming from the 0 byte grib2 files and removing them from the  simulation and porting a proper warning message. Resolving issue #45 