### PR TITLE
adding left out stofs_cur in scripts

### DIFF
--- a/scripts/exnwps_ofs_prep.sh
+++ b/scripts/exnwps_ofs_prep.sh
@@ -52,6 +52,11 @@ case ${OFSTYPE} in
         export err=$?; err_chk
         rm -rf ${RUNdir}/{*hourly,*hourly.spool}
     ;;
+    estofs_cur)
+        export CYCLE="${CYC}"
+        ${USHnwps}/make_estofs_cur.sh
+        export err=$?; err_chk
+    ;;
     rtofs)
         export CYCLE="00"
         ${USHnwps}/make_rtofs.sh


### PR DESCRIPTION
When upgrading to v1.5 due to the new stofs_cur job, we need to add it in the ofs_prep script as well. 