### PR TITLE
Changing COMINestofs to COMINstofs in OFS jobs 

### DIFF
--- a/dev/jobs/JNWPS_OFS_PREP
+++ b/dev/jobs/JNWPS_OFS_PREP
@@ -108,12 +108,7 @@ export COMIN=${COMROOT}/${NET}/${ver}/${OFS}.${PDY}
 export COMOUT=${COMROOT}/${NET}/${ver}/${OFS}.${PDY}
 export COMOUTm1=${COMROOT}/${NET}/${ver}/${OFS}.${PDYm1}
 export GESOUT=${COMROOT}/${NET}/$ver/${NET}.${PDY}/nwges
-#export COMINestofs=/lfs/h1/ops/prod/com/estofs/${estofs_ver}/estofs.${PDY}
-export COMINestofs=/lfs/h1/ops/prod/com/stofs/${stofs_ver}/stofs_2d_glo.${PDY}
-#### 10/01/22:  Realtime test of NCO Global STOFS parallel run 
 export COMINstofs=/lfs/h1/ops/prod/com/stofs/${stofs_ver}/stofs_2d_glo.${PDY}
-##### 09/16/22: Realtime test of Global STOFS upgrade ###############
-export COMINestofscur=/lfs/h1/ops/prod/com/stofs/${stofs_ver}/stofs_2d_glo.${PDY}
 #####################################################################
 export COMINrtofs=/lfs/h1/ops/prod/com/rtofs/${rtofs_ver}/rtofs.${PDY}
 export COMINsice=/lfs/h1/ops/prod/com/seaice_analysis/${seaice_analysis_ver}/seaice_analysis.${PDY}

--- a/jobs/JNWPS_OFS_PREP
+++ b/jobs/JNWPS_OFS_PREP
@@ -73,7 +73,7 @@ setpdy.sh
 ##############################################
 export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${nwps_ver})/${OFS}.${PDY}}
 export GESOUT=$(compath.py -o ${NET}/${nwps_ver})/${NET}.${PDY}/nwges
-export COMINestofs=${COMINestofs:-$(compath.py estofs/${estofs_ver}/estofs.${PDY})} 
+export COMINstofs=${COMINstofs:-$(compath.py stofs/${stofs_ver}/stofs_2d_glo.${PDY})}
 export COMINrtofs=${COMINrtofs:-$(compath.py rtofs/${rtofs_ver}/rtofs.${PDY})}
 export COMINsice=${COMINsice:-$(compath.py seaice_analysis/${seaice_analysis_ver}/seaice_analysis.${PDY})}
 export COMINsicem1=${COMINsicem1:-$(compath.py seaice_analysis/${seaice_analysis_ver}/seaice_analysis.${PDYm1})}

--- a/ush/make_estofs.sh
+++ b/ush/make_estofs.sh
@@ -195,19 +195,19 @@ function process_wfolist() {
         fi
 
         echo "Downloading ${SPOOLdir}/$file to $outfile" 
-        echo "Checking source GRIB2 file ${COMINestofs}/${file}"
-        if ! check_bad_grib2_file "${COMINestofs}/${file}"; then
-           warn_and_disable_estofs_grib2 "ESTOFS GRIB2 file ${COMINestofs}/${file} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
+        echo "Checking source GRIB2 file ${COMINstofs}/${file}"
+        if ! check_bad_grib2_file "${COMINstofs}/${file}"; then
+           warn_and_disable_estofs_grib2 "ESTOFS GRIB2 file ${COMINstofs}/${file} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
            rm -f ${OUTPUTdir}/LOCKFILE
            return
         fi
-        echo "cp -rp ${COMINestofs}/${file} ."
-        cp -rp ${COMINestofs}/${file} .
+        echo "cp -rp ${COMINstofs}/${file} ."
+        cp -rp ${COMINstofs}/${file} .
         if [ "$?" != "0" ] && [ ! -e ${file} ];then
            sleep 2
            echo "ERROR - downling file ${PRODUCTdir}/${file}" 
         fi
-        cp -rp ${COMINestofs}/${file} .
+        cp -rp ${COMINstofs}/${file} .
         if [ "$?" != "0" ] && [ ! -e ${file} ];then
            echo "ERROR - downling file ${PRODUCTdir}/${file}" 
            export err=1; err_chk
@@ -366,20 +366,20 @@ function process_wfolist() {
     	outfile="${file}"
     	cd ${PRODUCTdir}
     	if [ ! -e ${VARdir}/hasestofsdownload_${CYCLE}z.${ESTOFS_BASIN}.${ESTOFS_REGION}.f${FF} ];then
-            echo "Checking source GRIB2 file ${COMINestofs}/${file}"
-            if ! check_bad_grib2_file "${COMINestofs}/${file}"; then
-                warn_and_disable_estofs_grib2 "ESTOFS GRIB2 file ${COMINestofs}/${file} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
+            echo "Checking source GRIB2 file ${COMINstofs}/${file}"
+            if ! check_bad_grib2_file "${COMINstofs}/${file}"; then
+                warn_and_disable_estofs_grib2 "ESTOFS GRIB2 file ${COMINstofs}/${file} is missing or 0-byte. Run will continue without ESTOFS water level variation and ice blocking for ${WFO}."
                 rm -f ${OUTPUTdir}/LOCKFILE
                 return
             fi
-	        echo "Copying ${COMINestofs}/${file} ${PRODUCTdir}/${file}"
-	        echo "cp -rp ${COMINestofs}/${file} ."
-	        cp -rp ${COMINestofs}/${file} .
+	        echo "Copying ${COMINstofs}/${file} ${PRODUCTdir}/${file}"
+	        echo "cp -rp ${COMINstofs}/${file} ."
+	        cp -rp ${COMINstofs}/${file} .
 	        if [ "$?" != "0" ] && [ ! -e ${file} ];then
                 sleep 2
 	            echo "ERROR - downling file ${PRODUCTdir}/${file}" 
 	        fi
- 	        cp -rp ${COMINestofs}/${file} .
+ 	        cp -rp ${COMINstofs}/${file} .
 	        if [ "$?" != "0" ] && [ ! -e ${file} ];then
 	            echo "ERROR - downling file ${PRODUCTdir}/${file}" 
                 export err=1; err_chk

--- a/ush/make_estofs_cur.sh
+++ b/ush/make_estofs_cur.sh
@@ -158,19 +158,19 @@ function process_wfolist() {
 
         # Copy ESTOFS nowcast output
         echo "Downloading ${SPOOLdir}/$file1 to $outfile1" 
-        echo "cp -p ${COMINestofscur}/${file1} ."
-        if ! check_bad_nc_file "${COMINestofscur}/${file1}"; then
-           warn_and_disable_estofscur_nc "ESTOFS current file ${COMINestofscur}/${file1} is missing or 0-byte. Run will continue without ESTOFS current fields for ${WFO}."
+        echo "cp -p ${COMINstofs}/${file1} ."
+        if ! check_bad_nc_file "${COMINstofs}/${file1}"; then
+           warn_and_disable_estofscur_nc "ESTOFS current file ${COMINstofs}/${file1} is missing or 0-byte. Run will continue without ESTOFS current fields for ${WFO}."
            rm -f ${OUTPUTdir}/LOCKFILE
            return
         fi
-        cp -rp ${COMINestofscur}/${file1} .
+        cp -rp ${COMINstofs}/${file1} .
         sleep 10
         if [ "$?" != "0" ] && [ ! -e ${file1} ];then
            sleep 2
            echo "ERROR - downling file ${PRODUCTdir}/${file1}" 
         fi
-        cp -rp ${COMINestofscur}/${file1} .
+        cp -rp ${COMINstofs}/${file1} .
         sleep 10
         if [ "$?" != "0" ] && [ ! -e ${file1} ];then
            echo "ERROR - downling file ${PRODUCTdir}/${file1}" 
@@ -179,19 +179,19 @@ function process_wfolist() {
 
         # Copy ESTOFS forecast output
         echo "Downloading ${SPOOLdir}/$file2 to $outfile2" 
-        echo "cp -p ${COMINestofscur}/${file2} ."
-        if ! check_bad_nc_file "${COMINestofscur}/${file2}"; then
-           warn_and_disable_estofscur_nc "ESTOFS current file ${COMINestofscur}/${file2} is missing or 0-byte. Run will continue without ESTOFS current fields for ${WFO}."
+        echo "cp -p ${COMINstofs}/${file2} ."
+        if ! check_bad_nc_file "${COMINstofs}/${file2}"; then
+           warn_and_disable_estofscur_nc "ESTOFS current file ${COMINstofs}/${file2} is missing or 0-byte. Run will continue without ESTOFS current fields for ${WFO}."
            rm -f ${OUTPUTdir}/LOCKFILE
            return
         fi
-        cp -rp ${COMINestofscur}/${file2} .
+        cp -rp ${COMINstofs}/${file2} .
         sleep 10
         if [ "$?" != "0" ] && [ ! -e ${file2} ];then
            sleep 2
            echo "ERROR - downling file ${PRODUCTdir}/${file2}" 
         fi
-        cp -rp ${COMINestofscur}/${file2} .
+        cp -rp ${COMINstofs}/${file2} .
         sleep 10
         if [ "$?" != "0" ] && [ ! -e ${file2} ];then
            echo "ERROR - downling file ${PRODUCTdir}/${file2}" 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,4 @@
 export nwps_ver=v1.5.0
-export estofs_ver=v2.1
 export stofs_ver=v2.1
 export rtofs_ver=v2.5
 export seaice_analysis_ver=v4.5


### PR DESCRIPTION
This PR will remove any COMINestofs from the jobs and scripts and since the COMINstofs and COMINstofscur are the same path, the scripts are edited to remove the redundancy. 