### PR TITLE
Bringing in changes that were missing from ops for SENDDBN alert

### DIFF
--- a/ush/nwps_posproc_cg1.sh
+++ b/ush/nwps_posproc_cg1.sh
@@ -242,8 +242,8 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
         mkdir -p $COMOUTCYC
         cp -fv  ${OUTDIRrunup}/${filein} ${COMOUTCYC}/${filein}
         cp -fv  ${OUTDIRrunup}/${FORT22} ${COMOUTCYC}/${FORT22}
-	if [ "${SENDDBN}" == "YES" ]
-	then
+	    if [ "${SENDDBN}" == "YES" ]
+	    then
           echo "Sending ${FORT22} to DBNET."
           $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RUNUP ${job} ${COMOUTCYC}/${FORT22}
         fi

--- a/ush/nwps_posproc_cg1.sh
+++ b/ush/nwps_posproc_cg1.sh
@@ -339,7 +339,7 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
      if [ "$SENDDBN" = 'YES' ]
      then
          echo "Sending ${FORT23} to DBNET."
-	 $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RIPPROB ${job} ${COMOUTCYC}/${FORT23}
+	     $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RIPPROB ${job} ${COMOUTCYC}/${FORT23}
      fi
 
      mkdir -p $GESOUT/riphist/${SITEID}

--- a/ush/nwps_posproc_cg1.sh
+++ b/ush/nwps_posproc_cg1.sh
@@ -148,10 +148,10 @@ fi
 export PDY_INPUT="${yyyy}${mon}${dd}"
 
 # Prefer workflow cycle file; fallback to parsed hour
-cycle="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
-[ -z "${cycle}" ] && cycle="${hh}"
-cycle="$(printf '%02d' "${cycle#0}")"
-export cycle
+cycleout="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
+[ -z "${cycleout}" ] && cycleout="${hh}"
+cycleout="$(printf '%02d' "${cycleout#0}")"
+export cycleout
 
 # 3) Rebuild COMOUT for the correct day from the existing COMOUT path
 COMOUT_WFO="$(basename -- "$COMOUT")"            # -> <WFO> (site folder, e.g., box)
@@ -242,8 +242,10 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
         mkdir -p $COMOUTCYC
         cp -fv  ${OUTDIRrunup}/${filein} ${COMOUTCYC}/${filein}
         cp -fv  ${OUTDIRrunup}/${FORT22} ${COMOUTCYC}/${FORT22}
-        if [ "${SENDDBN}" == "YES" ]; then
-            ${DBNROOT}
+	if [ "${SENDDBN}" == "YES" ]
+	then
+          echo "Sending ${FORT22} to DBNET."
+          $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RUNUP ${job} ${COMOUTCYC}/${FORT22}
         fi
      fi
 
@@ -332,6 +334,13 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
      mkdir -p $COMOUTCYC
      cp -fv  ${RIPDATA}/${CGCONT} ${COMOUTCYC}/${CGCONT}
      cp -fv  ${RIPDATA}/${FORT23} ${COMOUTCYC}/${FORT23}
+
+
+     if [ "$SENDDBN" = 'YES' ]
+     then
+         echo "Sending ${FORT23} to DBNET."
+	 $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RIPPROB ${job} ${COMOUTCYC}/${FORT23}
+     fi
 
      mkdir -p $GESOUT/riphist/${SITEID}
      cp -fv  ${RIPDATA}/${CGCONT} ${GESOUT}/riphist/${SITEID}/${CGCONT}
@@ -538,7 +547,7 @@ cd ${DATA}/output/grib2/CG${CGNUM}
 	   
 	   if [ "${SITEID}" == "SEW" ] 
            then
-              for i in {10..59}; do
+              for i in {10..35}; do
                  mkdir -p ${COMOUTCYC}/PE00${i}/
                  cp -fv  ${RUNdir}/PE00${i}/${date_stamp}.${cycle}00* ${COMOUTCYC}/PE00${i}/
               done
@@ -648,6 +657,20 @@ cd ${DATA}/output/spectra/CG${CGNUM}
        done
      fi
 
+# ----------------------------------------
+# Send alerts to DBNet
+# ----------------------------------------
+if [ "${SENDDBN}" == "YES" ]; then
+  for file in ${spec2dFile}; do
+    suffix=$(echo "$file" | cut -d '.' -f2)
+    new_spc2d="nwps.t${cycle}z.spc2d_${suffix}_CG${CGNUM}.${WFO}.txt"
+    if [ -f "${COMOUTCYC}/${new_spc2d}" ]; then
+      echo "Sending ${new_spc2d} to DBNet"
+      $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_SPECTRA ${job} ${COMOUTCYC}/${new_spc2d}
+    fi
+  done
+fi
+
 export WEB="NO"
 echo " "  | tee -a $logfile
 
@@ -738,7 +761,7 @@ elif [ "${MODELCORE}" == "UNSWAN" ]
    
    if [ "${SITEID}" == "SEW" ] 
    then
-      for i in {10..59}; do
+      for i in {10..35}; do
          mkdir -p ${HOTdir}/PE00${i}
          for hour in {0..48..3}; do 
            mv -vf ${RUNdir}/PE00${i}/$(date -d "${hh}:${mm} ${yyyy}-${mon}-${dd} +${hour} hours" +"%Y%m%d.%H%M") \

--- a/ush/nwps_posproc_cgn_parallel.sh
+++ b/ush/nwps_posproc_cgn_parallel.sh
@@ -126,7 +126,7 @@ echo " " | tee -a $logrunup
 export inputparm="${RUNdir}/inputCG${CGNUM}"
 if [ ! -e ${inputparm} ]
 then
-   msg="FATAL ERROR: Runup program: Missing inputCG${CGNUM} file. Cannot open ${inputparm}"
+   msg="FATAL ERROR: Missing inputCG${CGNUM} file. Cannot open ${inputparm}"
    postmsg $jlogfile "$msg"
    export err=1; err_chk
 fi
@@ -147,10 +147,10 @@ fi
 export PDY_INPUT="${yyyy}${mon}${dd}"
 
 # Prefer workflow cycle file; fallback to parsed hour
-cycle="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
-[ -z "${cycle}" ] && cycle="${hh}"
-cycle="$(printf '%02d' "${cycle#0}")"
-export cycle
+cycleout="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
+[ -z "${cycleout}" ] && cycleout="${hh}"
+cycleout="$(printf '%02d' "${cycleout#0}")"
+export cycleout
 
 # 3) Rebuild COMOUT for the correct day from the existing COMOUT path
 COMOUT_WFO="$(basename -- "$COMOUT")"            # -> <WFO> (site folder, e.g., box)
@@ -233,14 +233,15 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
      cp -fv  ${FORT22} ${OUTDIRrunup}/${FORT22}
 
      cycle=$(awk '{print $1;}' ${RUNdir}/CYCLE)
-     OMOUTCYC="${COMOUT_CORRECT}/${cycle}/CG${CGNUM}"
-     
+     COMOUTCYC="${COMOUT_CORRECT}/${cycle}/CG${CGNUM}"
      if [ "${SENDCOM}" == "YES" ]; then
         mkdir -p $COMOUTCYC
         cp -fv  ${OUTDIRrunup}/${filein} ${COMOUTCYC}/${filein}
         cp -fv  ${OUTDIRrunup}/${FORT22} ${COMOUTCYC}/${FORT22}
-        if [ "${SENDDBN}" == "YES" ]; then
-            ${DBNROOT}
+        if [ "${SENDDBN}" == "YES" ]
+        then
+             echo "Sending ${FORT22} to DBNET."
+             $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RUNUP ${job} ${COMOUTCYC}/${FORT22}
         fi
      fi
 
@@ -317,6 +318,12 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
      mkdir -p $COMOUTCYC
      cp -fv  ${RIPDATA}/${CGCONT} ${COMOUTCYC}/${CGCONT}
      cp -fv  ${RIPDATA}/${FORT23} ${COMOUTCYC}/${FORT23}
+
+     if [ "$SENDDBN" = 'YES' ]
+     then
+         echo "Sending ${FORT23} to DBNET."
+         $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_RIPPROB ${job} ${COMOUTCYC}/${FORT23}
+     fi
 
      mkdir -p $GESOUT/riphist/${SITEID}
      cp -fv  ${RIPDATA}/${CGCONT} ${GESOUT}/riphist/${SITEID}/${CGCONT}
@@ -479,12 +486,30 @@ if [[ -d "${DATA}/output/spectra/CG${CGNUM}" ]]; then
    if [ "${SENDCOM}" == "YES" ]; then
       mkdir -p $COMOUTCYC
       for orig_file in ${spec2dFile}; do
-        suffix=$(echo "$orig_file" | cut -d '.' -f2)
-        new_spc2d="nwps.t${cycle}z.spc2d_${suffix}_CG${CGNUM}.${WFO}.txt"
-        cp -fv "$orig_file" "${COMOUTCYC}/${new_spc2d}"
+	suffix=$(echo "$orig_file" | cut -d '.' -f2)
+	new_spc2d="nwps.t${cycle}z.spc2d_${suffix}_CG${CGNUM}.${WFO}.txt"
+	cp -fv "$orig_file" "${COMOUTCYC}/${new_spc2d}"
       done
    fi
+  # ----------------------------------------
+  # Send alerts to DBNet
+  # ----------------------------------------
+  if [ "${SENDDBN}" == "YES" ]; then
+    for file in ${spec2dFile}; do
+      suffix=$(echo "$file" | cut -d '.' -f2)
+      new_spc2d="nwps.t${cycle}z.spc2d_${suffix}_CG${CGNUM}.${WFO}.txt"
+      if [ -f "${COMOUTCYC}/${new_spc2d}" ]; then
+        echo "Sending ${new_spc2d} to DBNet"
+        $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_SPECTRA ${job} ${COMOUTCYC}/${new_spc2d}
+      else
+        echo "Warning: ${COMOUTCYC}/${new_spc2d} does not exist, skipping DBNet alert"
+      fi
+    done
+  fi
+else
+   echo "Wave spectra not computed over this domain (CG${CGNUM})"
 fi
+
 #if [ "${WEB}" == "YES" ]
 #then
 #    echo "Sending output plots to Web" | tee -a $logfile

--- a/ush/nwps_posproc_cgn_parallel.sh
+++ b/ush/nwps_posproc_cgn_parallel.sh
@@ -486,9 +486,9 @@ if [[ -d "${DATA}/output/spectra/CG${CGNUM}" ]]; then
    if [ "${SENDCOM}" == "YES" ]; then
       mkdir -p $COMOUTCYC
       for orig_file in ${spec2dFile}; do
-	suffix=$(echo "$orig_file" | cut -d '.' -f2)
-	new_spc2d="nwps.t${cycle}z.spc2d_${suffix}_CG${CGNUM}.${WFO}.txt"
-	cp -fv "$orig_file" "${COMOUTCYC}/${new_spc2d}"
+	    suffix=$(echo "$orig_file" | cut -d '.' -f2)
+	    new_spc2d="nwps.t${cycle}z.spc2d_${suffix}_CG${CGNUM}.${WFO}.txt"
+	    cp -fv "$orig_file" "${COMOUTCYC}/${new_spc2d}"
       done
    fi
   # ----------------------------------------

--- a/ush/nwps_wavetrack_cg1.sh
+++ b/ush/nwps_wavetrack_cg1.sh
@@ -37,15 +37,15 @@ if [ "${hastracking}" == "TRUE" ]
    inputparm="${RUNdir}/inputCG1"
    if [ ! -e ${inputparm} ]
    then
-      msg="FATAL ERROR: Runup program: Missing inputCG1 file. Cannot open ${inputparm}"
+      msg="FATAL ERROR: Missing inputCG1 file. Cannot open ${inputparm}"
       postmsg $jlogfile "$msg"
       export err=1; err_chk
    fi
 
 
-   # 1) Parse YYYY MM DD HH MM from the INPGRID WIND line
+   # 1) Parse YYYY MM DD HH MM from the INPGRID WIND line (11th field)
    init="$(awk '/^INPGRID[[:space:]]+WIND/{print $11; exit}' "$inputparm")"  # e.g., 20250911.1800
-   ts="${init//[^0-9]/}"
+   ts="${init//[^0-9]/}"                          # strip any dot/underscore -> 202509111800
    yyyy="${ts:0:4}"; mon="${ts:4:2}"; dd="${ts:6:2}"; hh="${ts:8:2}"; mm="${ts:10:2}"
 
    # Sanity check
@@ -58,12 +58,13 @@ if [ "${hastracking}" == "TRUE" ]
    export PDY_INPUT="${yyyy}${mon}${dd}"
 
    # Prefer workflow cycle file; fallback to parsed hour
-   cycle="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
-   [ -z "${cycle}" ] && cycle="${hh}"
-   cycle="$(printf '%02d' "${cycle#0}")"
-   export cycle
+   cycleout="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
+   [ -z "${cycleout}" ] && cycleout="${hh}"
+   cycleout="$(printf '%02d' "${cycleout#0}")"
+   export cycleout
 
    # 3) Rebuild COMOUT for the correct day from the existing COMOUT path
+   #     COMOUT shape: .../<REGION>.<PDY>/<WFO>   (e.g., .../er.20250911/box)
    COMOUT_WFO="$(basename -- "$COMOUT")"            # -> <WFO> (site folder, e.g., box)
    COMOUT_PARENT="$(dirname -- "$COMOUT")"          # -> .../<REGION>.<PDY>
    REGION_DOT_PDY="$(basename -- "$COMOUT_PARENT")" # -> <REGION>.<PDY> (e.g., er.20250911)

--- a/ush/postprocess_partition_fields.sh
+++ b/ush/postprocess_partition_fields.sh
@@ -84,10 +84,10 @@ fi
 export PDY_INPUT="${yyyy}${mon}${dd}"
 
 # Prefer workflow cycle file; fallback to parsed hour
-cycle="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
-[ -z "${cycle}" ] && cycle="${hh}"
-cycle="$(printf '%02d' "${cycle#0}")"
-export cycle
+cycleout="$(awk 'NR==1{print $1}' "${RUNdir}/CYCLE" 2>/dev/null || true)"
+[ -z "${cycleout}" ] && cycleout="${hh}"
+cycleout="$(printf '%02d' "${cycleout#0}")"
+export cycleout
 
 # 3) Rebuild COMOUT for the correct day from the existing COMOUT path
 COMOUT_WFO="$(basename -- "$COMOUT")"            # -> <WFO> (site folder, e.g., box)


### PR DESCRIPTION
Back in Fall 2025, nwps.v1.4.23 was implemented with new alerts added to the model for rip current, runup and spectral outputs. Some parts of that code delivery are missing in the v1.5 branch and this PR will bring these changes in, along with some other differences that were noticed when comparing the ush scripts with ops package. @CarlosMDiaz-NCO if you could verify these changes, I would appreciate it.