### PR TITLE
Fix/dev run issues

### DIFF
--- a/dev/ecf/jnwps_prep.ecf.tmpl
+++ b/dev/ecf/jnwps_prep.ecf.tmpl
@@ -28,8 +28,8 @@
 #PBS -q dev
 #PBS -A NWPS-DEV
 #PBS -l walltime=01:25:00
-#PBS -l select=1:ncpus=120:mem=3000MB
-#PBS -l place=excl
+#PBS -l select=1:ncpus=120
+#PBS -l place=exclhost
 #PBS -l debug=true
 #PBS -V
 #PBS -o /lfs/h2/emc/ptmp/saeideh.banihashemi/com/nwps/v1.5.0/NWPS_%WFO%_prep.o

--- a/ush/nwps_posproc_cg1.sh
+++ b/ush/nwps_posproc_cg1.sh
@@ -250,7 +250,7 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
         fi
      fi
 
-     gribfile=$(ls ${DATA}/output/grib2/CG${CGNUM}/nwps.t*.CG${CGNUM}.???.grib2 | xargs -n 1 basename | tail -n 1)
+     gribfile=$(ls ${DATA}/output/grib2/CG${CGNUM}/nwps.t${cycle}*.CG${CGNUM}.???.grib2 | xargs -n 1 basename | tail -n 1)
      fullname=`echo $gribfile | cut -c14-26`
      GRIB2file=${NWPSDATA}/output/grib2/CG${CGNUM}/${gribfile}
      WAVE_RUNUP_TO_BIN="${EXECnwps}/nwps_utils_wave_runup_to_bin"
@@ -346,7 +346,7 @@ export COMOUT_CORRECT="${COMOUT_ROOT}/${REGION_ONLY}.${PDY_INPUT}/${COMOUT_WFO}"
      rip_current_meta="${RIPDATA}/RIP.meta"
      cat ${rip_current_meta_template} > ${rip_current_meta}
      RIP_CURRENT_TO_BIN="${EXECnwps}/nwps_utils_rip_current_to_bin"
-     gribfile=$(ls ${DATA}/output/grib2/CG${CGNUM}/nwps.t*.CG${CGNUM}.???.grib2 | xargs -n 1 basename | tail -n 1)
+     gribfile=$(ls ${DATA}/output/grib2/CG${CGNUM}/nwps.t{cycle}*.CG${CGNUM}.???.grib2 | xargs -n 1 basename | tail -n 1)
      fullname=`echo $gribfile | cut -c14-26`
      GRIB2file=${NWPSDATA}/output/grib2/CG${CGNUM}/${gribfile}
      cgnCLON1=$(${WGRIB2} ${GRIB2file} -V -d 1 | grep lon | grep to | grep by | awk '{ print $2 }')

--- a/ush/run_ripcurrent.sh
+++ b/ush/run_ripcurrent.sh
@@ -183,9 +183,9 @@ cat /dev/null > ${NWPSDATA}/logs/runrip.log
 
 # Find newest GRIB2 output file to process
 ls -lt ${NWPSDATA}/output/grib2/${CGnumber}
-gribfile=$(ls ${NWPSDATA}/output/grib2/${CGnumber}/*${CGnumber}*grib2 | xargs -n 1 basename | tail -n 1)
+gribfile=$(ls -t ${NWPSDATA}/output/grib2/${CGnumber}/*${CGnumber}*grib2 | xargs -n 1 basename | head -n 1)
 # Get the full path to the file
-gribpath=$(ls ${NWPSDATA}/output/grib2/${CGnumber}/*${CGnumber}*grib2 | tail -n 1)
+gribpath=$(ls -t ${NWPSDATA}/output/grib2/${CGnumber}/*${CGnumber}*grib2 | head -n 1)
 
 # 1. Extract the reference date/time using wgrib2
 # This outputs a string like "d=2026060912" (YYYYMMDDHH)


### PR DESCRIPTION
This PR will resolve the timing issue with submitted 18z forecaster winds in PDY+1. A memory issue in the dev prep job is also addressed to mimic prod and resolve "cannot allocate memory issue" 