### PR TITLE
make sure tar files have unique names

### DIFF
--- a/scripts/exnwps_ofs_prep.sh
+++ b/scripts/exnwps_ofs_prep.sh
@@ -67,7 +67,6 @@ case ${OFSTYPE} in
         export CYCLE="00"
         ${USHnwps}/make_psurge.sh
         export err=$?; err_chk
-        rm -rf ${COMOUT}/${OFSTYPE}/{*hourly,*hourly.spool}
     ;;
     *)
         echo "\$OFS type not found"
@@ -80,14 +79,18 @@ if [ ${SENDDBN} = YES ] && [ "${OFSTYPE}" != "stofs_cur" ]; then
     mkdir ${DATA}/tars
     for i in ${COMOUT}/${OFSTYPE}/*_output; do
         if [ "${OFSTYPE}" == "psurge" ]; then
+            epoc_waterlevel_start_time=`cat ${COMOUT}/psurge/${i##*/}_output/psurge_waterlevel_start_time.txt`
+            wldateinname_t=$(date -d @${epoc_waterlevel_start_time} +"%Y%m%d%T" )
+            TARCYCLE=${wldateinname_t:8:2}
             find ${i}/ -name *txt -exec basename '{}' ';' >> ${DATA}/tars/${i##*/}.list
-            find ${i}/ -name *gz -exec basename '{}' ';' >> ${DATA}/tars/${i##*/}.list
+            find ${i}/ -name wave_psurge_waterlevel_*_${TARCYCLE}_*_e*.dat.tar.gz -exec basename '{}' ';' >> ${DATA}/tars/${i##*/}.list
         else
             find ${i}/ -name wave_${OFSTYPE}*_${CYCLE}_*dat -exec basename '{}' ';' > ${DATA}/tars/${i##*/}.list
             find ${i}/ -name *txt -exec basename '{}' ';' >> ${DATA}/tars/${i##*/}.list
+	    TARCYCLE=${CYCLE}
         fi
 
-        echo "tar cvf ${DATA}/tars/${i##*/}.tar -C ${i} -T ${DATA}/tars/${i##*/}.list; if [ "$?" = "0" ]; then mv ${DATA}/tars/${i##*/}.tar ${COMOUT}/${OFSTYPE}/; $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_TAR $job ${COMOUT}/${OFSTYPE}/${i##*/}.tar; fi" >> ${DATA}/tars/tar_cmdfile
+        echo "tar cvf ${DATA}/tars/${i##*/}_${TARCYCLE}.tar -C ${i} -T ${DATA}/tars/${i##*/}.list; if [ "$?" = "0" ]; then mv ${DATA}/tars/${i##*/}_${TARCYCLE}.tar ${COMOUT}/${OFSTYPE}/; $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_TAR $job ${COMOUT}/${OFSTYPE}/${i##*/}_${TARCYCLE}.tar; fi" >> ${DATA}/tars/tar_cmdfile
     done
     #aprun -n24 -N24 -j1 -d1 cfp ${DATA}/tars/tar_cmdfile
     mpiexec -np 24 --cpu-bind verbose,core cfp ${DATA}/tars/tar_cmdfile

--- a/scripts/exnwps_ofs_prep.sh
+++ b/scripts/exnwps_ofs_prep.sh
@@ -89,8 +89,9 @@ if [ ${SENDDBN} = YES ] && [ "${OFSTYPE}" != "stofs_cur" ]; then
             find ${i}/ -name *txt -exec basename '{}' ';' >> ${DATA}/tars/${i##*/}.list
 	    TARCYCLE=${CYCLE}
         fi
-
-        echo "tar cvf ${DATA}/tars/${i##*/}_${TARCYCLE}.tar -C ${i} -T ${DATA}/tars/${i##*/}.list; if [ "$?" = "0" ]; then mv ${DATA}/tars/${i##*/}_${TARCYCLE}.tar ${COMOUT}/${OFSTYPE}/; $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_TAR $job ${COMOUT}/${OFSTYPE}/${i##*/}_${TARCYCLE}.tar; fi" >> ${DATA}/tars/tar_cmdfile
+        
+	tarfilename=nwps.t${TARCYCLE}z.${i##*/}.tar
+        echo "tar cvf ${DATA}/tars/${tarfilename} -C ${i} -T ${DATA}/tars/${i##*/}.list; if [ "$?" = "0" ]; then mv ${DATA}/tars/${tarfilename} ${COMOUT}/${OFSTYPE}/; $DBNROOT/bin/dbn_alert MODEL NWPS_ASCII_TAR $job ${COMOUT}/${OFSTYPE}/${tarfilename}; fi" >> ${DATA}/tars/tar_cmdfile
     done
     #aprun -n24 -N24 -j1 -d1 cfp ${DATA}/tars/tar_cmdfile
     mpiexec -np 24 --cpu-bind verbose,core cfp ${DATA}/tars/tar_cmdfile

--- a/ush/make_psurge_init.sh
+++ b/ush/make_psurge_init.sh
@@ -147,6 +147,21 @@ if [ "${NewestPsurge}" == "" ]
     export err=1; err_chk
 fi
 
+# Determine what the latest cycle of psurge is by grabbing the latest ZZz from the file names:
+z_cycle=$((shopt -s nullglob; printf '%s\n' ${PSurge_latest}/psurge.${YYYYMMDD}/psurge.t${YYYYMMDD}*z.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2) | sed -n 's|.*/psurge\.t[0-9]\{8\}\([0-9]\{2\}\)z.*|\1|p' | sort -n | tail -n1)
+
+#Update CYCLE definition:
+# Check for command line CYCLE
+
+if [ "$1" != "" ]
+then
+   CYCLE="$1"
+else
+   export CYCLE=${zcycle:-00}
+   echo ""
+   echo "Cycle being set based on psurge data, CYCLE=${CYCLE}"
+fi
+
 #psurge.t2004091418z.al822004_e10_inc_dat.conus_625m.grib2
 split=(${NewestPsurge//_/ })
 for part in ${split[@]} ; do echo $part; done
@@ -154,7 +169,7 @@ for part in ${split[@]} ; do echo $part; done
 #cp ${PSurge_latest}/${split[0]}_e??_inc_dat.h102.conus_625m.grib2 ${RUNdir} 
 #cp ${PSurge_latest}/${split[0]}_e[1-5]?_inc_dat.h102.conus_625m.grib2 ${RUNdir} 
 # psurge update v3.0 
-for srcfile in ${PSurge_latest}/psurge.${YYYYMMDD}/*.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2
+for srcfile in ${PSurge_latest}/psurge.${YYYYMMDD}/*${CYCLE}z.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2
 do
    if [ -f "${srcfile}" ]; then
       if ! check_bad_grib2_file "${srcfile}"; then
@@ -167,7 +182,9 @@ do
       fi
    fi
 done
-cp ${PSurge_latest}/psurge.${YYYYMMDD}/*.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2 ${RUNdir}
+
+# only copy the latest cycle data 
+cp ${PSurge_latest}/psurge.${YYYYMMDD}/*${CYCLE}z.${NewestPsurge}_e[1-5]?_inc_dat.h102.conus_625m.grib2 ${RUNdir}
 cd $workdir
 #--------------------------------------------------------------
 


### PR DESCRIPTION
It was noticed by data flow that tar files with the same name were alerted multiple times.  

This PR creates tar files for stofs for each cycle.   
RTOFS is only being created once, but it also has a cycle added to it's name. 
PSURGE updates included: 
* getting a cycle from psurge_waterlevel_start_time.txt 
* Updating the tar file to only include the .dat.tar.gz from this cycle 
* Adding cycle to the tar file name. 


This means that each tar file for data flow will be unique while only modifying the tar files which are otherwise not used in operations. 

Another solution would involve instead creating subfolder of each cycle in the ofs.YYYYMMDD folders.  This is the ideal solution, however will be a much more invasive update requiring updates not only the the ofs prep job, but the other prep jobs that use ofs_prep data and how it searches for back-up data. 